### PR TITLE
736: Extend highlighted layer to work for circle features

### DIFF
--- a/addon/components/labs-layers.js
+++ b/addon/components/labs-layers.js
@@ -246,7 +246,13 @@ export default Component.extend({
           this.set('hoveredFeature', feature);
 
           map.getSource('hovered-feature').setData(feature);
-          map.setLayoutProperty('highlighted-feature', 'visibility', 'visible');
+          if(feature.layer.type == "circle") {
+            map.setLayoutProperty('highlighted-feature-circle', 'visibility', 'visible');
+            map.setLayoutProperty('highlighted-feature-line', 'visibility', 'none');
+          } else {
+            map.setLayoutProperty('highlighted-feature-circle', 'visibility', 'none');
+            map.setLayoutProperty('highlighted-feature-line', 'visibility', 'visible');
+          }
         }
 
         map.getCanvas().style.cursor = 'pointer';
@@ -262,7 +268,8 @@ export default Component.extend({
         mousePosition: null,
       });
 
-      map.setLayoutProperty('highlighted-feature', 'visibility', 'none');
+      map.setLayoutProperty('highlighted-feature-circle', 'visibility', 'none');
+      map.setLayoutProperty('highlighted-feature-line', 'visibility', 'none');
 
       const mouseLeaveEvent = this.get('onLayerMouseLeave');
 

--- a/addon/components/labs-map.js
+++ b/addon/components/labs-map.js
@@ -4,10 +4,36 @@ import { get } from '@ember/object';
 import { computed } from '@ember/object';
 import layout from '../templates/components/labs-map';
 
-export const highlightedFeatureLayer = {
-  id: 'highlighted-feature',
-  type: 'line',
+const highlightedCircleFeatureLayer = {
+  id: 'highlighted-feature-circle',
   source: 'hovered-feature',
+  type: 'circle',
+  paint: {
+    'circle-color': 'rgba(255, 255, 255, 0.65)',
+    'circle-opacity': 1,
+    'circle-radius': {
+      stops: [
+        [16, 3],
+        [17, 6],
+      ],
+    },
+    'circle-stroke-opacity': {
+      stops: [
+        [15, 0],
+        [16, 0.8],
+      ],
+    },
+    'circle-stroke-color': '#ffff00',
+    'circle-stroke-width': 2.5,
+    'circle-pitch-scale': 'map',
+  },
+};
+
+
+const highlightedLineFeatureLayer = {
+  id: 'highlighted-feature-line',
+  source: 'hovered-feature',
+  type: 'line',
   paint: {
     'line-color': '#ffff00',
     'line-opacity': 0.3,
@@ -48,10 +74,10 @@ export default mapboxGlMap.extend({
 
     // if layerGroups are passed to the map, use the style from that
     if (this.get('layerGroups')) {
-      const { 
+      const {
         meta: {
-          mapboxStyle 
-        } 
+          mapboxStyle
+        }
       } = this.get('layerGroups') || {};
 
       if (mapboxStyle) assign(get(this, 'initOptions') || {}, { style: mapboxStyle });
@@ -60,7 +86,6 @@ export default mapboxGlMap.extend({
 
   layout,
 
-  
   hoveredFeatureSource: computed('hoveredFeature', function() {
     const feature = this.get('hoveredFeature');
 
@@ -71,13 +96,8 @@ export default mapboxGlMap.extend({
   }),
 
   hoveredFeature: null,
-
-  /**
-    MapboxGL Style object for the hightlighted layer
-    @argument highlightedFeatureLayer
-    @type Object
-  */
-  highlightedFeatureLayer,
+  highlightedCircleFeatureLayer,
+  highlightedLineFeatureLayer,
 
   /**
     Collection of layer-group models (see: [DS.RecordArray](https://emberjs.com/api/ember-data/release/classes/DS.RecordArray)).

--- a/addon/templates/components/labs-map.hbs
+++ b/addon/templates/components/labs-map.hbs
@@ -7,7 +7,12 @@
     {{!-- Highlighted Layer Handling --}}
     {{mapbox-gl-layer
       map=map
-      layer=highlightedFeatureLayer}}
+      layer=highlightedLineFeatureLayer
+    }} 
+    {{mapbox-gl-layer
+      map=map
+      layer=highlightedCircleFeatureLayer
+    }}
 
     {{yield (hash
       mapInstance=map


### PR DESCRIPTION

<img width="246" alt="screen shot 2019-02-04 at 5 15 16 pm" src="https://user-images.githubusercontent.com/6502129/52241015-9d460180-28a0-11e9-8fa3-6a442a37746e.png">
<img width="243" alt="screen shot 2019-02-04 at 5 15 27 pm" src="https://user-images.githubusercontent.com/6502129/52241016-9d460180-28a0-11e9-8439-5923f9f3dcba.png">

Creates an additional highlight layer in the labs-layer component template.
Defined in labs-layer component, the highlight layers are of type circle and line, to be displayed in conjunction to achieve full highlighting of line and circle layer features.