### PR TITLE
Fix singleton setters

### DIFF
--- a/addon/models/layer-group.js
+++ b/addon/models/layer-group.js
@@ -76,7 +76,7 @@ export default Model.extend({
     get() {
       return this.get('layers').findBy('visibility', true);
     },
-    set(id) {
+    set(key, id) {
       this.get('layers').setEach('visibility', false);
       this.get('layers').findBy('id', id).set('visibility', true);
     }

--- a/addon/models/layer.js
+++ b/addon/models/layer.js
@@ -111,7 +111,7 @@ export default Model.extend({
     },
   }),
 
-  /** 
+  /**
     Getter and setter for visibility. Mutates a Mapbox property that actually determines visibility. Depends on parent visibility.
 
     @property visibility
@@ -121,10 +121,12 @@ export default Model.extend({
     get() {
       return this.get('layout.visibility') === 'visible';
     },
-    set(value) {
+    set(key, value) {
       const parentVisibilityState = value && this.get('layerGroup.visible');
       const visibility = (parentVisibilityState ? 'visible' : 'none');
       const layout = copy(this.get('layout'));
+
+
 
       if (layout) {
         set(layout, 'visibility', visibility);

--- a/addon/models/layer.js
+++ b/addon/models/layer.js
@@ -126,12 +126,12 @@ export default Model.extend({
       const visibility = (parentVisibilityState ? 'visible' : 'none');
       const layout = copy(this.get('layout'));
 
-
-
       if (layout) {
         set(layout, 'visibility', visibility);
         this.set('layout', layout);
       }
+
+      return visibility === 'visible';
     },
   }),
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ember-copy": "1.0.0",
     "ember-fetch": "5.1.3",
     "ember-truth-helpers": "^2.0.0",
+    "lodash": "^4.17.11",
     "mapbox-gl": ">=0.47.0",
     "pretender": "2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,12 +4555,6 @@ ember-tether@^1.0.0-beta.2:
     ember-cli-node-assets "^0.2.2"
     tether "^1.4.0"
 
-ember-truth-helpers@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.0.0.tgz#f3e2eef667859197f1328bb4f83b0b35b661c1ac"
-  dependencies:
-    ember-cli-babel "^6.8.2"
-
 ember-truth-helpers@^2.0.0, ember-truth-helpers@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz#d4dab4eee7945aa2388126485977baeb33ca0798"


### PR DESCRIPTION
Calling `set(value)` passes value to method as `set(key, value) {}`

This PR updates `set()` definitions to use the second argument as `value` instead of the first.  Fixes https://github.com/NYCPlanning/labs-zola/issues/776

Should be published to npm as a patch upgrade (v0.2.1)