### PR TITLE
Fix `labs-layers` for Point type features

### DIFF
--- a/addon/components/labs-layers.js
+++ b/addon/components/labs-layers.js
@@ -173,7 +173,8 @@ export default Component.extend({
     // we don't need to union if there is only one
     // we also don't want to slow down machines if there are too many
     if (featureFragments.length === 1 || featureFragments.length > 100) return feature;
-
+    // if the fragments are features of type "Point", return the first one instead of unioning
+    if (featureFragments.length > 0 && featureFragments[0].geometry.type === "Point") return featureFragments[0];
     return featureFragments
       .reduce((acc, curr) => turfUnion(curr, (acc ? acc : curr)));
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-mapbox-composer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
### Summary
This change tweaks labs-layers so that it can handle `Point` type features. Before this, there was a bug where it would attempt to call `turfUnion()` on these features, which only works for Polygons and Multipolygons. Functionality for polygon layers should be unaffected, so this technically isn't a breaking change.